### PR TITLE
replace explicit http:// with // for jquery

### DIFF
--- a/examples/flatland/index.html
+++ b/examples/flatland/index.html
@@ -61,7 +61,7 @@
 		<script type="text/javascript" src="../../src/linebreak.js"></script>
 		<script type="text/javascript" src="../../lib/hypher.js"></script>
 		<script type="text/javascript" src="../../lib/en-us.js"></script>
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
 		<script type="text/javascript">
 			jQuery(function ($) {
 				var lineLength = 0,


### PR DESCRIPTION
Without this change, the example will fail if served from a HTTPS website (for most browsers).

With the change, the browser will conditionally fetch jquery either over HTTP or HTTPS, depending on what protocol is in use when the example is served.
